### PR TITLE
added babel-plugin-transform-runtime and babel-polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -11,5 +11,6 @@
         }
       }
     ]
-  ]
+  ], 
+  "plugins": ["transform-runtime"]
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-
+require("babel-polyfill");
 const fs = require("fs");
 const MemoryFs = require("memory-fs");
 const webpack = require("webpack");
@@ -43,7 +43,7 @@ program
  */
 function compile(entry) {
   const compiler = webpack({
-    entry: entry,
+    entry: ["babel-polyfill", entry],
     output: {
       filename: BUNDLE_FILE_NAME,
       path: "/"

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-loader": "^7.1.2",
+    "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-polyfill": "^6.26.0",
     "babel-preset-env": "^1.6.1",
     "commander": "^2.11.0",
     "dotenv-webpack": "^1.5.4",


### PR DESCRIPTION
@tszarzynski User can now use async/await in their service worker code. However, they will also need to install babel-polyfill into their CRA build. Unfortunately, this seems to be the only way to get this to work. 